### PR TITLE
Fix apiVersion for memcached deploy with kube 1.16

### DIFF
--- a/kubernetes/memcached.yml
+++ b/kubernetes/memcached.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
I think this should fix the latest deploy error:
```
error: unable to recognize "/tmp/Deployment-memcached20201014-786-j07zx.yml": no matches for kind "Deployment" in version "extensions/v1beta1"
```